### PR TITLE
Redirect to setup

### DIFF
--- a/api/v1/index.php
+++ b/api/v1/index.php
@@ -2,7 +2,7 @@
 
 // Starchat API v0.7.2
 
-include '../../mysqlinfo.php';
+require '../../mysqlinfo.php';
 // Check if connection works
 if ($conn->connect_error) {
 	die("Connection failed: " . $conn->connect_error);

--- a/create.php
+++ b/create.php
@@ -1,5 +1,5 @@
 <?php
-include 'mysqlinfo.php';
+require 'mysqlinfo.php';
 
 if (isset($_GET["trycreate"])) {
 

--- a/home.php
+++ b/home.php
@@ -1,6 +1,6 @@
 <?php
 session_start();
-include 'mysqlinfo.php';
+require 'mysqlinfo.php';
 
 // Check connection
 if ($conn->connect_error) {

--- a/index.php
+++ b/index.php
@@ -1,6 +1,12 @@
 <?php
 session_start();
-include 'mysqlinfo.php';
+if(!file_exists('mysqlinfo.php')) {
+    header("Location: setup.php");
+    die("You should be <a href='setup.php'>here</a>");
+}
+
+require 'mysqlinfo.php';
+
 $is_error = false;
 $error;
 $is_success = false;


### PR DESCRIPTION
Hi, I've prepared a new commit
**New stuff**

- If mysqlinfo.php does not exists and the user opens index.php it redirect the user instantly to setup.php
- I replaced all include with require. The difference is that the program continues working with include but it dies with require when the file is missing and mysqlinfo.php is basicly required for everything and starchat does not work without it.